### PR TITLE
add custom endpoints and localisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,20 @@ composer require ossycodes/friendlycaptcha
 
 ### Configuration
 
-Add `FRIENDLY_CAPTCHA_SECRET` and `FRIENDLY_CAPTCHA_SITEKEY` in **.env** file :
+Add `FRIENDLY_CAPTCHA_SECRET`, `FRIENDLY_CAPTCHA_SITEKEY` and optional `FRIENDLY_CAPTCHA_PUZZLE_ENDPOINT`, `FRIENDLY_CAPTCHA_VERIFY_ENDPOINT` in **.env** file :
 
 ```
 FRIENDLY_CAPTCHA_SECRET=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 FRIENDLY_CAPTCHA_SITEKEY=XXXXXXXXXXXXXXXX
+FRIENDLY_CAPTCHA_PUZZLE_ENDPOINT=https://api.friendlycaptcha.com/api/v1/puzzle #optional
+FRIENDLY_CAPTCHA_VERIFY_ENDPOINT=https://api.friendlycaptcha.com/api/v1/siteverify #optional
 ```
 
 You can obtain your site-key from [here](https://docs.friendlycaptcha.com/#/installation?id=_1-generating-a-sitekey) and secret from [here](https://apiserver-prod.friendlycaptcha.eu/dashboard/accounts/1118678876/apikeys)
 
 ## Usage
 
-In your layout file, include the FriendlyCaptcha widget scripts using the `@friendlyCaptchaRenderWidgetScripts` Blade directive. This should be added to the `<head>` of your document.
+For FriendlyCaptcha widget scripts from a CDN, add the Blade directive `@friendlyCaptchaRenderWidgetScripts` in your layout file. This should be added to the `<head>` of your document.
 
 ```blade
 <html>
@@ -48,13 +50,25 @@ or if you don't want to use the Blade directive you can do this instead
 
 You have two options on how to add the script tag either from unpkg (default) or from jsdelivr
 
-@friendlyCaptchaRenderWidgetScripts()
+`@friendlyCaptchaRenderWidgetScripts()`
 or
-@friendlyCaptchaRenderWidgetScripts('jsdelivr')
+`@friendlyCaptchaRenderWidgetScripts('jsdelivr')`
 
-{!! FriendlyCaptcha::renderWidgetScripts() !!}
+`{!! FriendlyCaptcha::renderWidgetScripts() !!}`
 or
-{!! FriendlyCaptcha::renderWidgetScripts('jsdelivr') !!}
+`{!! FriendlyCaptcha::renderWidgetScripts('jsdelivr') !!}`
+
+You can also host the FriendlyCaptcha widget scripts yourself:
+
+```
+npm install --save friendly-challenge@0.9.9
+```
+
+And import it in your app:
+
+```js
+import "friendly-challenge/widget";
+```
 
 
 Once that's done, you can call the `renderWidget()` method  in `<form>` to output the appropriate markup (friendlycaptcha widget) with your site key configured.

--- a/lang/de/validation.php
+++ b/lang/de/validation.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Validation Language Lines
+|--------------------------------------------------------------------------
+*/
+
+return [
+    'secret_missing' => 'Sie haben vergessen, den Parameter secret (=API-Schlüssel) hinzuzufügen.',
+    'secret_invalid' => 'Der von Ihnen angegebene API-Schlüssel war ungültig.',
+    'solution_missing' => 'Sie haben vergessen, den Parameter secret (=API-Schlüssel) hinzuzufügen.',
+    'secret_missing' => 'Sie haben vergessen, den Lösungsparameter hinzuzufügen.',
+    'bad_request' => 'Mit Ihrer Anfrage ist etwas anderes nicht in Ordnung, z. B. ist Ihr Anfragekörper leer.',
+    'solution_invalid' => 'Die von Ihnen angegebene Lösung war ungültig (vielleicht wurde versucht, das Rätsel zu manipulieren).',
+    'solution_timeout_or_duplicate' => 'Das Rätsel, für das Sie die Lösung angegeben haben, ist abgelaufen oder wurde bereits verwendet.',
+    'unexpected' => 'Ein unerwarteter Fehler ist aufgetreten.'
+];

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Validation Language Lines
+|--------------------------------------------------------------------------
+*/
+
+return [
+    'secret_missing' => 'You forgot to add the secret (=API key) parameter.',
+    'secret_invalid' => 'The API key you provided was invalid.',
+    'solution_missing' => 'You forgot to add the secret (=API key) parameter.',
+    'secret_missing' => 'You forgot to add the solution parameter.',
+    'bad_request' => 'Something else is wrong with your request, e.g. your request body is empty.',
+    'solution_invalid' => 'The solution you provided was invalid (perhaps the user tried to tamper with the puzzle).',
+    'solution_timeout_or_duplicate' => 'The puzzle that the solution was for has expired or has already been used.',
+    'unexpected' => 'An unexpected error occurred.'
+];

--- a/src/FriendlyCaptcha.php
+++ b/src/FriendlyCaptcha.php
@@ -173,8 +173,6 @@ class FriendlyCaptcha
      */
     protected function sendRequestVerify(array $data = [])
     {
-        //dd($data);
-
         $response = $this->http->request('POST', $this->verify, [
             'form_params' => $data,
         ]);

--- a/src/FriendlyCaptchaServiceProvider.php
+++ b/src/FriendlyCaptchaServiceProvider.php
@@ -28,6 +28,8 @@ class FriendlyCaptchaServiceProvider extends ServiceProvider
         $this->bootBladeDirectives();
 
         $this->bootMacro();
+
+        $this->bootLang();
     }
 
     /**
@@ -75,6 +77,16 @@ class FriendlyCaptchaServiceProvider extends ServiceProvider
     }
 
     /**
+     * boot lang
+     */
+    public function bootLang()
+    {
+        Rule::macro('friendlycaptcha', function () {
+            $this->loadTranslationsFrom(__DIR__.'/../lang', 'friendlycaptcha');
+        });
+    }
+
+    /**
      * Register the application services.
      */
     public function register()
@@ -87,6 +99,8 @@ class FriendlyCaptchaServiceProvider extends ServiceProvider
             return new FriendlyCaptcha(
                 $app['config']['friendlycaptcha.secret'],
                 $app['config']['friendlycaptcha.sitekey'],
+                $app['config']['friendlycaptcha.puzzle_endpoint'],
+                $app['config']['friendlycaptcha.verify_endpoint'],
                 $app['config']['friendlycaptcha.options']
             );
         });

--- a/src/Rules/FriendlyCaptcha.php
+++ b/src/Rules/FriendlyCaptcha.php
@@ -46,25 +46,25 @@ class FriendlyCaptcha implements Rule
     {
         switch ($code) {
             case "secret_missing":
-                return "You forgot to add the secret (=API key) parameter.";
+                return __('validation.secret_missing');
                 break;
             case "secret_invalid":
-                return "The API key you provided was invalid.";
+                return __('validation.secret_invalid');
                 break;
             case "solution_missing":
-                return "You forgot to add the solution parameter.";
+                return __('validation.solution_missing');
                 break;
             case "bad_request":
-                return "Something else is wrong with your request, e.g. your request body is empty.";
+                return __('validation.bad_request');
                 break;
             case "solution_invalid":
-                return "The solution you provided was invalid (perhaps the user tried to tamper with the puzzle).";
+                return __('validation.solution_invalid');
                 break;
             case "solution_timeout_or_duplicate":
-                return "The puzzle that the solution was for has expired or has already been used.";
+                return __('validation.solution_timeout_or_duplicate');
                 break;
             default:
-                return  "An unexpected error occurred.";
+                return  __('validation.unexpected');
         }
     }
 }

--- a/src/config/friendlycaptcha.php
+++ b/src/config/friendlycaptcha.php
@@ -3,7 +3,7 @@
 return [
     'secret'            => env('FRIENDLY_CAPTCHA_SECRET'),
     'sitekey'           => env('FRIENDLY_CAPTCHA_SITEKEY'),
-    'puzzle_endpoint'   => env('FRIENDLY_CAPTCHA_PUZZLE_ENDPOINT', 'https://api.friendlycaptcha.eu/api/v1/puzzle'),
+    'puzzle_endpoint'   => env('FRIENDLY_CAPTCHA_PUZZLE_ENDPOINT', 'https://api.friendlycaptcha.com/api/v1/puzzle'),
     'verify_endpoint'   => env('FRIENDLY_CAPTCHA_VERIFY_ENDPOINT', 'https://api.friendlycaptcha.com/api/v1/siteverify'),
     'options'           => [
         'timeout'       => 30,

--- a/src/config/friendlycaptcha.php
+++ b/src/config/friendlycaptcha.php
@@ -3,6 +3,8 @@
 return [
     'secret'            => env('FRIENDLY_CAPTCHA_SECRET'),
     'sitekey'           => env('FRIENDLY_CAPTCHA_SITEKEY'),
+    'puzzle_endpoint'   => env('FRIENDLY_CAPTCHA_PUZZLE_ENDPOINT', 'https://api.friendlycaptcha.eu/api/v1/puzzle'),
+    'verify_endpoint'   => env('FRIENDLY_CAPTCHA_VERIFY_ENDPOINT', 'https://api.friendlycaptcha.com/api/v1/siteverify'),
     'options'           => [
         'timeout'       => 30,
         'http_errors'   => false,


### PR DESCRIPTION
support custom endpoints
set language by app localisation
add description for self hosted js
add error localisations
update cdn js version to 0.9.9
support single error attribute (occours in self hosted server with wrong api key)

custom endpoints are usefull for endpoint in europe or self hosted server