### PR TITLE
v4.0.0 — FriendlyCaptcha v2 API (fixes from PR #10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to `ossycodes/friendlycaptcha` will be documented in this file
 
+## 2.0.0 - 2026-04.08
+- Replace the friendly-challenge scripts
+```html
+<script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.12/widget.module.min.js" async defer></script>
+<script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.12/widget.min.js" async defer></script>
+```
+with the new @friendlycaptcha/sdk scripts
+```html
+<script type="module" src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.2.0/site.min.js"
+        async defer></script>
+<script nomodule src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.2.0/site.compat.min.js"
+      async defer></script>
+```
+
+For more information visit: https://developer.friendlycaptcha.com/docs/v2/guides/upgrading-from-v1/script
+
 ## 1.0.0 - 2021-10-21
 
 - initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to `ossycodes/friendlycaptcha` will be documented in this file
 
-## 2.0.0 - 2026-04.08
+## 4.0.0 - 2026-04-08
 - Replace the friendly-challenge scripts
 ```html
 <script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.12/widget.module.min.js" async defer></script>

--- a/lang/de/validation.php
+++ b/lang/de/validation.php
@@ -7,12 +7,13 @@
 */
 
 return [
-    'secret_missing' => 'Sie haben vergessen, den Parameter secret (=API-Schlüssel) hinzuzufügen.',
-    'secret_invalid' => 'Der von Ihnen angegebene API-Schlüssel war ungültig.',
-    'solution_missing' => 'Sie haben vergessen, den Parameter secret (=API-Schlüssel) hinzuzufügen.',
-    'secret_missing' => 'Sie haben vergessen, den Lösungsparameter hinzuzufügen.',
     'bad_request' => 'Mit Ihrer Anfrage ist etwas anderes nicht in Ordnung, z. B. ist Ihr Anfragekörper leer.',
-    'solution_invalid' => 'Die von Ihnen angegebene Lösung war ungültig (vielleicht wurde versucht, das Rätsel zu manipulieren).',
-    'solution_timeout_or_duplicate' => 'Das Rätsel, für das Sie die Lösung angegeben haben, ist abgelaufen oder wurde bereits verwendet.',
+    'auth_required' => 'Authentifizierung erforderlich.',
+    'auth_invalid' => 'Authentifizierung fehlgeschlagen.',
+    'sitekey_invalid' => 'Der Sitekey ist ungültig.',
+    'response_missing' => 'Die Captcha-Lösung fehlt.',
+    'response_invalid' => 'Die Captcha-Lösung ist falsch.',
+    'response_timeout' => 'Anfrage abgelaufen.',
+    'response_duplicate' => 'Diese Lösung wurde bereits verwendet.',
     'unexpected' => 'Ein unerwarteter Fehler ist aufgetreten.'
 ];

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -7,12 +7,13 @@
 */
 
 return [
-    'secret_missing' => 'You forgot to add the secret (=API key) parameter.',
-    'secret_invalid' => 'The API key you provided was invalid.',
-    'solution_missing' => 'You forgot to add the secret (=API key) parameter.',
-    'secret_missing' => 'You forgot to add the solution parameter.',
     'bad_request' => 'Something else is wrong with your request, e.g. your request body is empty.',
-    'solution_invalid' => 'The solution you provided was invalid (perhaps the user tried to tamper with the puzzle).',
-    'solution_timeout_or_duplicate' => 'The puzzle that the solution was for has expired or has already been used.',
+    'auth_required' => 'Authentification required.',
+    'auth_invalid' => 'Authentification failed.',
+    'sitekey_invalid' => 'The sitekey is invalid.',
+    'response_missing' => 'The captcha solution is missing.',
+    'response_invalid' => 'The captcha solution is invalid.',
+    'response_timeout' => 'Connection timed out.',
+    'response_duplicate' => 'This solution has already been used.',
     'unexpected' => 'An unexpected error occurred.'
 ];

--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -8,8 +8,8 @@
 
 return [
     'bad_request' => 'Something else is wrong with your request, e.g. your request body is empty.',
-    'auth_required' => 'Authentification required.',
-    'auth_invalid' => 'Authentification failed.',
+    'auth_required' => 'Authentication required.',
+    'auth_invalid' => 'Authentication failed.',
     'sitekey_invalid' => 'The sitekey is invalid.',
     'response_missing' => 'The captcha solution is missing.',
     'response_invalid' => 'The captcha solution is invalid.',

--- a/src/FriendlyCaptcha.php
+++ b/src/FriendlyCaptcha.php
@@ -3,6 +3,7 @@
 namespace Ossycodes\FriendlyCaptcha;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 
 class FriendlyCaptcha
 {
@@ -35,7 +36,7 @@ class FriendlyCaptcha
     public $isSuccess = false;
 
     /**
-     * @var \GuzzleHttp\Client
+     * @var Client
      */
     protected $http;
 
@@ -114,6 +115,7 @@ class FriendlyCaptcha
      * @param string $solution
      *
      * @return bool
+     * @throws GuzzleException
      */
     public function verifyRequest(string $solution)
     {
@@ -128,6 +130,7 @@ class FriendlyCaptcha
      * @param string $solution
      *
      * @return self
+     * @throws GuzzleException
      */
     public function verifyResponse(string $solution)
     {
@@ -168,6 +171,7 @@ class FriendlyCaptcha
      * @param array $headers
      * @param array $data
      * @return array
+     * @throws GuzzleException
      */
     protected function sendRequestVerify(array $headers = [], array $data = []): array
     {

--- a/src/FriendlyCaptcha.php
+++ b/src/FriendlyCaptcha.php
@@ -21,11 +21,6 @@ class FriendlyCaptcha
     protected $sitekey;
 
     /**
-     * FriendlyCaptcha Puzzle endpoint
-     */
-    protected $puzzle;
-
-    /**
      * FriendlyCaptcha verify endpoint
      */
     protected $verify;
@@ -44,27 +39,19 @@ class FriendlyCaptcha
      */
     protected $http;
 
-    public function __construct($secret, $sitekey, $puzzle, $verify, $options = [])
+    public function __construct($secret, $sitekey, $verify, $options = [])
     {
         $this->secret   = $secret;
         $this->sitekey  = $sitekey;
-        $this->puzzle   = $puzzle;
         $this->verify   = $verify;
         $this->http     = new Client($options);
     }
 
-    public function renderWidgetScripts($option = 'unpkg')
+    public function renderWidgetScripts(): string
     {
-        if ($option == 'unpkg') {
-            return <<<EOF
-                <script type="module" src="https://unpkg.com/friendly-challenge@0.9.9/widget.module.min.js" async defer></script>
-                <script nomodule src="https://unpkg.com/friendly-challenge@0.9.9/widget.min.js" async defer></script>
-              EOF;
-        }
-
         return <<<EOF
-                <script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.9/widget.module.min.js" async defer></script>
-                <script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.9/widget.min.js" async defer></script>
+                <script type="module" src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.36/site.min.js" async defer></script>
+                <script nomodule src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.36/site.compat.min.js" async defer></script>
             EOF;
     }
 
@@ -83,8 +70,6 @@ class FriendlyCaptcha
      */
     protected function prepareAttributes(array $attributes)
     {
-        $attributes['data-puzzle-endpoint'] = $this->puzzle;
-
         $attributes['data-sitekey'] = $this->sitekey;
 
         if (isset($attributes['dark-theme'])) {
@@ -130,7 +115,7 @@ class FriendlyCaptcha
      *
      * @return bool
      */
-    public function verifyRequest($solution)
+    public function verifyRequest(string $solution)
     {
         return $this->verifyResponse(
             $solution,
@@ -144,17 +129,19 @@ class FriendlyCaptcha
      *
      * @return self
      */
-    public function verifyResponse($solution)
+    public function verifyResponse(string $solution)
     {
         if (empty($solution)) {
             return false;
         }
 
-        $verifyResponse = $this->sendRequestVerify([
-            'solution' => $solution,
-            'secret'   => $this->secret,
-            'sitekey'  => $this->sitekey,
-        ]);
+        $verifyResponse = $this->sendRequestVerify(
+            ['X-API-Key' => $this->secret],
+            [
+                'response' => $solution,
+                'sitekey'  => $this->sitekey,
+            ]
+        );
 
         if (isset($verifyResponse['success']) && $verifyResponse['success'] === true) {
             $this->isSuccess = true;
@@ -178,13 +165,14 @@ class FriendlyCaptcha
     /**
      * Send verify request.
      *
+     * @param array $headers
      * @param array $data
-     *
      * @return array
      */
-    protected function sendRequestVerify(array $data = [])
+    protected function sendRequestVerify(array $headers = [], array $data = []): array
     {
         $response = $this->http->request('POST', $this->verify, [
+            'headers' => $headers,
             'form_params' => $data,
         ]);
 

--- a/src/FriendlyCaptcha.php
+++ b/src/FriendlyCaptcha.php
@@ -31,7 +31,7 @@ class FriendlyCaptcha
      *
      * @var array
      */
-    protected $error = [];
+    protected $errors = [];
 
     public $isSuccess = false;
 
@@ -51,8 +51,8 @@ class FriendlyCaptcha
     public function renderWidgetScripts(): string
     {
         return <<<EOF
-                <script type="module" src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.36/site.min.js" async defer></script>
-                <script nomodule src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.36/site.compat.min.js" async defer></script>
+                <script type="module" src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.2.0/site.min.js" async defer></script>
+                <script nomodule src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.2.0/site.compat.min.js" async defer></script>
             EOF;
     }
 
@@ -132,10 +132,12 @@ class FriendlyCaptcha
      * @return self
      * @throws GuzzleException
      */
-    public function verifyResponse(string $solution)
+    public function verifyResponse(string $solution): self
     {
         if (empty($solution)) {
-            return false;
+            $this->isSuccess = false;
+            $this->errors = [];
+            return $this;
         }
 
         $verifyResponse = $this->sendRequestVerify(
@@ -177,7 +179,7 @@ class FriendlyCaptcha
     {
         $response = $this->http->request('POST', $this->verify, [
             'headers' => $headers,
-            'form_params' => $data,
+            'json' => $data,
         ]);
 
         return json_decode($response->getBody(), true);

--- a/src/FriendlyCaptchaServiceProvider.php
+++ b/src/FriendlyCaptchaServiceProvider.php
@@ -49,19 +49,10 @@ class FriendlyCaptchaServiceProvider extends ServiceProvider
      */
     public function bootBladeDirectives()
     {
-        Blade::directive('friendlyCaptchaRenderWidgetScripts', function ($option) {
-            $option = trim($option, "'");
-
-            if (empty($option) || $option == 'unpkg') {
-                return <<<EOF
-                        <script type="module" src="https://unpkg.com/friendly-challenge@0.9.8/widget.module.min.js" async defer></script>
-                        <script nomodule src="https://unpkg.com/friendly-challenge@0.9.8/widget.min.js" async defer></script>
-                    EOF;
-            }
-
+        Blade::directive('friendlyCaptchaRenderWidgetScripts', function () {
             return <<<EOF
-                    <script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.8/widget.module.min.js" async defer></script>
-                    <script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.8/widget.min.js" async defer></script>
+                    <script type="module" src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.36/site.min.js" async defer></script>
+                    <script nomodule src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.36/site.compat.min.js" async defer></script>
                 EOF;
         });
     }

--- a/src/FriendlyCaptchaServiceProvider.php
+++ b/src/FriendlyCaptchaServiceProvider.php
@@ -25,11 +25,11 @@ class FriendlyCaptchaServiceProvider extends ServiceProvider
             $this->bootConfig();
         }
 
+        $this->loadTranslationsFrom(__DIR__.'/../lang', 'friendlycaptcha');
+
         $this->bootBladeDirectives();
 
         $this->bootMacro();
-
-        $this->bootLang();
     }
 
     /**
@@ -51,8 +51,8 @@ class FriendlyCaptchaServiceProvider extends ServiceProvider
     {
         Blade::directive('friendlyCaptchaRenderWidgetScripts', function () {
             return <<<EOF
-                    <script type="module" src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.36/site.min.js" async defer></script>
-                    <script nomodule src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.36/site.compat.min.js" async defer></script>
+                    <script type="module" src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.2.0/site.min.js" async defer></script>
+                    <script nomodule src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.2.0/site.compat.min.js" async defer></script>
                 EOF;
         });
     }
@@ -64,16 +64,6 @@ class FriendlyCaptchaServiceProvider extends ServiceProvider
     {
         Rule::macro('friendlycaptcha', function () {
             return app(\Ossycodes\FriendlyCaptcha\Rules\FriendlyCaptcha::class);
-        });
-    }
-
-    /**
-     * boot lang
-     */
-    public function bootLang()
-    {
-        Rule::macro('friendlycaptcha', function () {
-            $this->loadTranslationsFrom(__DIR__.'/../lang', 'friendlycaptcha');
         });
     }
 

--- a/src/FriendlyCaptchaServiceProvider.php
+++ b/src/FriendlyCaptchaServiceProvider.php
@@ -90,7 +90,6 @@ class FriendlyCaptchaServiceProvider extends ServiceProvider
             return new FriendlyCaptcha(
                 $app['config']['friendlycaptcha.secret'],
                 $app['config']['friendlycaptcha.sitekey'],
-                $app['config']['friendlycaptcha.puzzle_endpoint'],
                 $app['config']['friendlycaptcha.verify_endpoint'],
                 $app['config']['friendlycaptcha.options']
             );

--- a/src/Rules/FriendlyCaptcha.php
+++ b/src/Rules/FriendlyCaptcha.php
@@ -59,6 +59,8 @@ class FriendlyCaptcha implements Rule
                 return __('validation.response_timeout');
             case "response_duplicate":
                 return __('validation.response_duplicate');
+            case "bad_request":
+                return __('validation.bad_request');
             default:
                 return  __('validation.unexpected');
         }

--- a/src/Rules/FriendlyCaptcha.php
+++ b/src/Rules/FriendlyCaptcha.php
@@ -45,24 +45,20 @@ class FriendlyCaptcha implements Rule
     protected function mapErrorCodeToMessage(string $code): string
     {
         switch ($code) {
-            case "secret_missing":
-                return __('validation.secret_missing');
-                break;
-            case "secret_invalid":
-                return __('validation.secret_invalid');
-                break;
-            case "solution_missing":
-                return __('validation.solution_missing');
-                break;
-            case "bad_request":
-                return __('validation.bad_request');
-                break;
-            case "solution_invalid":
-                return __('validation.solution_invalid');
-                break;
-            case "solution_timeout_or_duplicate":
-                return __('validation.solution_timeout_or_duplicate');
-                break;
+            case "auth_required":
+                return __('validation.auth_required');
+            case "auth_invalid":
+                return __('validation.auth_invalid');
+            case "sitekey_invalid":
+                return __('validation.sitekey_invalid');
+            case "response_missing":
+                return __('validation.response_missing');
+            case "response_invalid":
+                return __('validation.response_invalid');
+            case "response_timeout":
+                return __('validation.response_timeout');
+            case "response_duplicate":
+                return __('validation.response_duplicate');
             default:
                 return  __('validation.unexpected');
         }

--- a/src/Rules/FriendlyCaptcha.php
+++ b/src/Rules/FriendlyCaptcha.php
@@ -2,14 +2,13 @@
 
 namespace Ossycodes\FriendlyCaptcha\Rules;
 
-use Illuminate\Contracts\Validation\Rule;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Ossycodes\FriendlyCaptcha\FriendlyCaptcha as FriendlyCaptchaClient;
 
-class FriendlyCaptcha implements Rule
+class FriendlyCaptcha implements ValidationRule
 {
     protected $friendlyCaptchaClient;
-
-    protected array $messages = [];
 
     public function __construct(
         FriendlyCaptchaClient $friendlyCaptcha
@@ -17,52 +16,40 @@ class FriendlyCaptcha implements Rule
         $this->friendlyCaptchaClient = $friendlyCaptcha;
     }
 
-    public function passes($attribute, $value)
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         $response = $this->friendlyCaptchaClient->verifyResponse($value);
 
         if ($response->isSuccess()) {
-            return true;
+            return;
         }
 
         foreach ($response->getErrors() as $errorCode) {
-            $this->messages[] = $this->mapErrorCodeToMessage($errorCode);
+            $fail($this->mapErrorCodeToMessage($errorCode));
         }
-
-        return false;
     }
 
-    public function message()
-    {
-        return $this->messages;
-    }
-
-    /**
-     * map FriendlyCaptcha error code to human readable validation message
-     *
-     * @var string $code
-     */
     protected function mapErrorCodeToMessage(string $code): string
     {
         switch ($code) {
             case "auth_required":
-                return __('validation.auth_required');
+                return __('friendlycaptcha::validation.auth_required');
             case "auth_invalid":
-                return __('validation.auth_invalid');
+                return __('friendlycaptcha::validation.auth_invalid');
             case "sitekey_invalid":
-                return __('validation.sitekey_invalid');
+                return __('friendlycaptcha::validation.sitekey_invalid');
             case "response_missing":
-                return __('validation.response_missing');
+                return __('friendlycaptcha::validation.response_missing');
             case "response_invalid":
-                return __('validation.response_invalid');
+                return __('friendlycaptcha::validation.response_invalid');
             case "response_timeout":
-                return __('validation.response_timeout');
+                return __('friendlycaptcha::validation.response_timeout');
             case "response_duplicate":
-                return __('validation.response_duplicate');
+                return __('friendlycaptcha::validation.response_duplicate');
             case "bad_request":
-                return __('validation.bad_request');
+                return __('friendlycaptcha::validation.bad_request');
             default:
-                return  __('validation.unexpected');
+                return __('friendlycaptcha::validation.unexpected');
         }
     }
 }

--- a/src/config/friendlycaptcha.php
+++ b/src/config/friendlycaptcha.php
@@ -3,8 +3,7 @@
 return [
     'secret'            => env('FRIENDLY_CAPTCHA_SECRET'),
     'sitekey'           => env('FRIENDLY_CAPTCHA_SITEKEY'),
-    'puzzle_endpoint'   => env('FRIENDLY_CAPTCHA_PUZZLE_ENDPOINT', 'https://api.friendlycaptcha.com/api/v1/puzzle'),
-    'verify_endpoint'   => env('FRIENDLY_CAPTCHA_VERIFY_ENDPOINT', 'https://api.friendlycaptcha.com/api/v1/siteverify'),
+    'verify_endpoint'   => env('FRIENDLY_CAPTCHA_VERIFY_ENDPOINT', 'https://global.frcapi.com/api/v2/captcha/siteverify'), //see https://developer.friendlycaptcha.com/docs/v2/guides/upgrading-from-v1/backend-integration
     'options'           => [
         'timeout'       => 30,
         'http_errors'   => false,

--- a/tests/FriendlyCaptchaTest.php
+++ b/tests/FriendlyCaptchaTest.php
@@ -22,21 +22,7 @@ class FriendlyCaptchaTest extends TestCase
     {
         parent::setUp();
 
-        $this->captcha = new FriendlyCaptcha('{secret-key}', '{site-key}', 'https://api.friendlycaptcha.com/api/v1/puzzle', 'https://api.friendlycaptcha.com/api/v1/siteverify');
-    }
-
-    /**
-     * @test
-     */
-    public function it_can_render_unpkg_widget_script_correctly()
-    {
-        $this->assertTrue($this->captcha instanceof FriendlyCaptcha);
-
-        $expectedScriptOne  = '<script type="module" src="https://unpkg.com/friendly-challenge@0.9.9/widget.module.min.js" async defer></script>';
-        $expectedScriptTwo  = '<script nomodule src="https://unpkg.com/friendly-challenge@0.9.9/widget.min.js" async defer></script>';
-
-        $this->assertStringContainsString($expectedScriptOne, $this->captcha->renderWidgetScripts());
-        $this->assertStringContainsString($expectedScriptTwo, $this->captcha->renderWidgetScripts());
+        $this->captcha = new FriendlyCaptcha('{secret-key}', '{site-key}', 'https://global.frcapi.com/api/v2/captcha/siteverify');
     }
 
     /**
@@ -46,11 +32,11 @@ class FriendlyCaptchaTest extends TestCase
     {
         $this->assertTrue($this->captcha instanceof FriendlyCaptcha);
 
-        $expectedScriptOne = '<script type="module" src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.9/widget.module.min.js" async defer></script>';
-        $expectedScriptTwo = '<script nomodule src="https://cdn.jsdelivr.net/npm/friendly-challenge@0.9.9/widget.min.js" async defer></script>';
+        $expectedScriptOne = '<script type="module" src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.36/site.min.js" async defer></script>';
+        $expectedScriptTwo = '<script nomodule src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.36/site.compat.min.js" async defer></script>';
 
-        $this->assertStringContainsString($expectedScriptOne, $this->captcha->renderWidgetScripts('jsdelivr'));
-        $this->assertStringContainsString($expectedScriptTwo, $this->captcha->renderWidgetScripts('jsdelivr'));
+        $this->assertStringContainsString($expectedScriptOne, $this->captcha->renderWidgetScripts());
+        $this->assertStringContainsString($expectedScriptTwo, $this->captcha->renderWidgetScripts());
     }
 
     /**
@@ -60,8 +46,8 @@ class FriendlyCaptchaTest extends TestCase
     {
         $this->assertTrue($this->captcha instanceof FriendlyCaptcha);
 
-        $expectedWidget = '<div data-puzzle-endpoint="https://api.friendlycaptcha.com/api/v1/puzzle" data-sitekey="{site-key}" class="frc-captcha" data-lang="en"></div>';
-        $expectedWidgetWithCustomAttributes = '<div data-puzzle-endpoint="https://api.friendlycaptcha.com/api/v1/puzzle" data-sitekey="{site-key}" class="frc-captcha dark"></div>';
+        $expectedWidget = '<div data-sitekey="{site-key}" class="frc-captcha" data-lang="en"></div>';
+        $expectedWidgetWithCustomAttributes = '<div data-sitekey="{site-key}" class="frc-captcha dark"></div>';
 
         $this->assertEquals($expectedWidget, $this->captcha->renderWidget());
         $this->assertEquals($expectedWidgetWithCustomAttributes, $this->captcha->renderWidget(['dark-theme' => true]));

--- a/tests/FriendlyCaptchaTest.php
+++ b/tests/FriendlyCaptchaTest.php
@@ -14,7 +14,7 @@ class FriendlyCaptchaTest extends TestCase
     }
 
     /**
-     * @var FriendlyCaptchaTest
+     * @var FriendlyCaptcha
      */
     private $captcha;
 
@@ -25,24 +25,18 @@ class FriendlyCaptchaTest extends TestCase
         $this->captcha = new FriendlyCaptcha('{secret-key}', '{site-key}', 'https://global.frcapi.com/api/v2/captcha/siteverify');
     }
 
-    /**
-     * @test
-     */
-    public function it_can_render_jsdelivr_widget_script_correctly()
+    public function test_it_can_render_widget_scripts_correctly()
     {
         $this->assertTrue($this->captcha instanceof FriendlyCaptcha);
 
-        $expectedScriptOne = '<script type="module" src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.36/site.min.js" async defer></script>';
-        $expectedScriptTwo = '<script nomodule src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.1.36/site.compat.min.js" async defer></script>';
+        $expectedScriptOne = '<script type="module" src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.2.0/site.min.js" async defer></script>';
+        $expectedScriptTwo = '<script nomodule src="https://cdn.jsdelivr.net/npm/@friendlycaptcha/sdk@0.2.0/site.compat.min.js" async defer></script>';
 
         $this->assertStringContainsString($expectedScriptOne, $this->captcha->renderWidgetScripts());
         $this->assertStringContainsString($expectedScriptTwo, $this->captcha->renderWidgetScripts());
     }
 
-    /**
-     * @test
-     */
-    public function it_can_render_widget_correctly()
+    public function test_it_can_render_widget_correctly()
     {
         $this->assertTrue($this->captcha instanceof FriendlyCaptcha);
 


### PR DESCRIPTION
## Summary

This PR applies all the fixes identified during review of #10 by @KRMM2025 and prepares the codebase for a `v4.0.0` major release. All credit for the v2 API migration goes to @KRMM2025 — this branch just addresses the bugs before merging.

**Changes from #10:**

| # | Issue | Fix |
|---|-------|-----|
| 1 | `verifyResponse()` returned `false` (bool) → fatal `TypeError` in `Rules::passes()` | Always returns `$this`; sets `isSuccess = false` on empty input |
| 2 | `bootLang()` overwrote `bootMacro()`'s `Rule::macro` → `Rule::friendlycaptcha()` crashed | Removed `bootLang()`; translations loaded directly in `boot()` |
| 3 | `$error` declared but `$errors` used → dynamic property, `getErrors()` returned `null` | Renamed declared property to `$errors` |
| 4 | `Illuminate\Contracts\Validation\Rule` removed in Laravel 12 | Replaced with `Illuminate\Contracts\Validation\ValidationRule` + `validate()` |
| 5 | `form_params` sends form-encoded; v2 API expects JSON | Switched to `json` key in Guzzle request |
| 6 | `@test` annotations removed in PHPUnit 11 → no tests found | Renamed methods with `test_` prefix |
| 7 | SDK version inconsistency (`@0.1.36` in code, `@0.2.0` in CHANGELOG) | Aligned all files to `@0.2.0` |
| 8 | Translations never actually registered | Handled by fix #2 |

## Test plan
- [ ] CI passes across PHP 8.1–8.4 × Laravel 10–13
- [ ] `Rule::friendlycaptcha()` returns a rule instance
- [ ] Empty captcha submission returns validation error, not 500
- [ ] Translations load correctly via `friendlycaptcha::validation.*`

@KRMM2025 — could you review this and confirm the v2 API behaviour looks correct from your testing? Happy to adjust anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)